### PR TITLE
update on node-oauth broke passport-windowslive

### DIFF
--- a/lib/passport-windowslive/strategy.js
+++ b/lib/passport-windowslive/strategy.js
@@ -3,7 +3,8 @@
  */
 var util = require('util')
   , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError;
+  , InternalOAuthError = require('passport-oauth').InternalOAuthError
+  , request = require('request');
 
 
 /**
@@ -69,9 +70,9 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://apis.live.net/v5.0/me', accessToken, function (err, body, res) {
+  request.get('https://apis.live.net/v5.0/me?access_token=' + accessToken, function (err, resp, body) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
       

--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
   "name": "passport-windowslive",
   "version": "0.1.2",
   "description": "Windows Live authentication strategy for Passport.",
-  "keywords": ["passport", "microsoft", "windowslive", "msn", "hotmail", "auth", "authn", "authentication", "identity"],
+  "keywords": [
+    "passport",
+    "microsoft",
+    "windowslive",
+    "msn",
+    "hotmail",
+    "auth",
+    "authn",
+    "authentication",
+    "identity"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/jaredhanson/passport-windowslive.git"
@@ -15,14 +25,17 @@
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib/passport-windowslive",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "~0.1.2"
+    "passport-oauth": "~0.1.2",
+    "request": "~2.14.0"
   },
   "devDependencies": {
     "vows": "0.6.x"
@@ -30,5 +43,7 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 0.4.0"
+  }
 }


### PR DESCRIPTION
Hi Jared,

This is a quick fix that will use the [request](https://github.com/mikeal/request) module instead of node-oauth `get` method (https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js#L173). The problem is that Windows Live will reject the request to the API if the access token is sent both as a header and the query string (see [this thread](http://social.msdn.microsoft.com/Forums/en-US/messengerconnect/thread/5c7c6271-c0fb-4b90-b6e2-a5a6250b3847)). This started to surface since node-oauth was bumped 4 days ago including this new change that was committed four months ago (https://github.com/ciaranj/node-oauth/commits/master)

I didn't check if the OAuth spec says something about sending the access token in both places. This was an issue for us in production, so we took the easiest and more decoupled route.
