### PR TITLE
Updated strategy to support locale and display parameters

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,6 +57,33 @@ function Strategy(options, verify) {
  */
 util.inherits(Strategy, OAuth2Strategy);
 
+/**
+ * Return extra parameters to be included in the authorization request.
+ *
+ * Valid parameters are:
+ *
+ *  - `locale`    The display type to be used for the authorization page. 
+ *                Valid values are "popup", "touch", "page", or "none".
+ *  - `display`   Optional. A market string that determines how the consent UI 
+ *                is localized. If the value of this parameter is missing or is
+ *                not valid, a market value is determined by using an internal 
+ *                algorithm.
+ *                
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function(options) {
+  var params = {};
+
+  ['locale', 'display'].forEach(function(name) {
+    if (options[name]) {
+      params[name] = options[name]
+    }
+  });
+
+  return params;
+};
 
 /**
  * Retrieve user profile from Windows Live.


### PR DESCRIPTION
Adds support for locale and display parameters, as specified here: http://msdn.microsoft.com/en-us/library/hh243647.aspx

The display parameter is useful because Microsoft doesn't do automatic device detection on the login page, so the only way to force a mobile-optimized view is by passing in "touch" as the display value.