### PR TITLE
Added prompt option to the authorizationParams array

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -73,7 +73,7 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.authorizationParams = function(options) {
   var params = {};
 
-  ['locale', 'display'].forEach(function(name) {
+  ['locale', 'display', 'prompt'].forEach(function(name) {
     if (options[name]) {
       params[name] = options[name]
     }


### PR DESCRIPTION
In order to enable forced login prompting parameter, e.g.: &prompt=login, see Issue #16.